### PR TITLE
Update service and agent templates for cso-default

### DIFF
--- a/terraformer/pkg/terraformer/compiler.go
+++ b/terraformer/pkg/terraformer/compiler.go
@@ -46,7 +46,7 @@ func buildNamespaces(def *terraformerv1.AppRoleDefinition, env string) (suffixPr
 		return nil, err
 	}
 
-	// Builb processors map
+	// Build processors map
 	return map[csov1.Ring]struct {
 		prefix     []string
 		suffixFunc func() []*terraformerv1.AppRoleDefinitionSecretSuffix

--- a/terraformer/pkg/terraformer/templates.go
+++ b/terraformer/pkg/terraformer/templates.go
@@ -67,6 +67,7 @@ resource "vault_approle_auth_backend_role" "{{.ObjectName}}" {
   role_name = "{{.ObjectName}}"
 
   token_policies = [
+	"cso-default",
 	"service-default",
     "service-{{.ObjectName}}",
   ]
@@ -119,6 +120,7 @@ resource "vault_approle_auth_backend_role" "agent-{{.ObjectName}}" {
   role_name = "{{.ObjectName}}"
 
   token_policies = [
+	"cso-default",
 	"agent-default",
     "agent-{{.ObjectName}}",
   ]


### PR DESCRIPTION
- Update service and agent templates for `cso-default` to allow for a `common` policy definition.
- Updates the release workflow for `arm64` binaries for `harp-terraformer`.

Rel: https://github.com/elastic/cloud-accesses/pull/1619