### PR TITLE
github-actions: actions/cache@v2 will be retired by February 1st, 2025

### DIFF
--- a/.github/workflows/release-harp-server.yml
+++ b/.github/workflows/release-harp-server.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           install: true
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-multi-buildx-server-${{ matrix.golang-version }}-${{ github.sha }}

--- a/.github/workflows/release-harp-terraformer.yml
+++ b/.github/workflows/release-harp-terraformer.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           install: true
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-multi-buildx-terraformer-${{ matrix.golang-version }}-${{ github.sha }}


### PR DESCRIPTION
See https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down