### PR TITLE
feat: add policy subcommand to render a vault policy without an approle backend

### DIFF
--- a/terraformer/cmd/harp-terraformer/internal/cmd/policy.go
+++ b/terraformer/cmd/harp-terraformer/internal/cmd/policy.go
@@ -1,0 +1,79 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+
+	"github.com/elastic/harp-plugins/terraformer/pkg/terraformer"
+	"github.com/elastic/harp/pkg/sdk/cmdutil"
+	"github.com/elastic/harp/pkg/sdk/log"
+)
+
+var (
+	terraformerPolicyInputSpec   string
+	terraformerPolicyOutputPath  string
+	terraformerPolicyEnvironment string
+)
+
+// -----------------------------------------------------------------------------
+
+var terraformerPolicyCmd = func() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "policy",
+		Short: "Policy generator for Harp CSO Vault",
+		Run:   runTerraformerPolicy,
+	}
+
+	// Parameters
+	cmd.Flags().StringVar(&terraformerPolicyInputSpec, "spec", "-", "AppRole specification path ('-' for stdin or filename)")
+	cmd.Flags().StringVar(&terraformerPolicyOutputPath, "out", "-", "Output file ('-' for stdout or a filename)")
+	cmd.Flags().StringVar(&terraformerPolicyEnvironment, "env", "production", "Target environment")
+
+	return cmd
+}
+
+func runTerraformerPolicy(cmd *cobra.Command, _ []string) {
+	ctx, cancel := cmdutil.Context(cmd.Context(), "harp-terraformer-policy", conf.Debug.Enable, conf.Instrumentation.Logs.Level)
+	defer cancel()
+
+	var (
+		reader io.Reader
+		err    error
+	)
+
+	// Create input reader
+	reader, err = cmdutil.Reader(terraformerPolicyInputSpec)
+	if err != nil {
+		log.For(ctx).Fatal("unable to open input specification", zap.Error(err), zap.String("path", terraformerPolicyInputSpec))
+	}
+
+	// Create output writer
+	writer, err := cmdutil.Writer(terraformerPolicyOutputPath)
+	if err != nil {
+		log.For(ctx).Fatal("unable to create output writer", zap.Error(err), zap.String("path", terraformerPolicyOutputPath))
+	}
+
+	// Run terraformer
+	if err := terraformer.Run(ctx, reader, terraformerPolicyEnvironment, true, terraformer.PolicyTemplate, writer); err != nil {
+		log.For(ctx).Fatal("unable to process specification", zap.Error(err), zap.String("path", terraformerPolicyInputSpec))
+	}
+}

--- a/terraformer/cmd/harp-terraformer/internal/cmd/root.go
+++ b/terraformer/cmd/harp-terraformer/internal/cmd/root.go
@@ -57,6 +57,7 @@ var mainCmd = func() *cobra.Command {
 
 	// Add subcommands
 	cmd.AddCommand(terraformerAgentCmd())
+	cmd.AddCommand(terraformerPolicyCmd())
 	cmd.AddCommand(terraformerServiceCmd())
 
 	// Return command

--- a/terraformer/pkg/terraformer/compiler.go
+++ b/terraformer/pkg/terraformer/compiler.go
@@ -209,6 +209,7 @@ var allowedCapabilities = types.StringArray{
 	"read",
 	"update",
 	"delete",
+	"sudo",
 }
 
 // filterCapabilities removes useless capabilities


### PR DESCRIPTION
## Notes for your reviewers

- [x] Introduce the `sudo` permissions as a potential option when defining an operation for a path.
- [x] Add the `policy` subcommand to the `harp-terraformer` command to support the generation of a policy without an approle.