### PR TITLE
feat: add approle subcommand with noEnvironmentSuffix option

### DIFF
--- a/terraformer/cmd/harp-terraformer/internal/cmd/agent.go
+++ b/terraformer/cmd/harp-terraformer/internal/cmd/agent.go
@@ -29,10 +29,11 @@ import (
 )
 
 var (
-	terraformerAgentInputSpec        string
-	terraformerAgentOutputPath       string
-	terraformerAgentDisableTokenWrap bool
-	terraformerAgentEnvironment      string
+	terraformerAgentInputSpec                string
+	terraformerAgentOutputPath               string
+	terraformerAgentDisableTokenWrap         bool
+	terraformerAgentDisableEnvironmentSuffix bool
+	terraformerAgentEnvironment              string
 )
 
 // -----------------------------------------------------------------------------
@@ -49,6 +50,7 @@ var terraformerAgentCmd = func() *cobra.Command {
 	cmd.Flags().StringVar(&terraformerAgentOutputPath, "out", "-", "Output file ('-' for stdout or a filename)")
 	cmd.Flags().StringVar(&terraformerAgentEnvironment, "env", "production", "Target environment")
 	cmd.Flags().BoolVar(&terraformerAgentDisableTokenWrap, "no-token-wrap", false, "Disable token wrapping")
+	cmd.Flags().BoolVar(&terraformerAgentDisableEnvironmentSuffix, "no-env-suffix", false, "Disable environment suffix in role and policy names")
 
 	return cmd
 }
@@ -75,7 +77,7 @@ func runTerraformerAgent(cmd *cobra.Command, _ []string) {
 	}
 
 	// Run terraformer
-	if err := terraformer.Run(ctx, reader, terraformerAgentEnvironment, terraformerAgentDisableTokenWrap, terraformer.AgentTemplate, writer); err != nil {
+	if err := terraformer.Run(ctx, reader, terraformerAgentEnvironment, terraformerAgentDisableTokenWrap, terraformerAgentDisableEnvironmentSuffix, terraformer.AgentTemplate, writer); err != nil {
 		log.For(ctx).Fatal("unable to process specification", zap.Error(err), zap.String("path", terraformerAgentInputSpec))
 	}
 }

--- a/terraformer/cmd/harp-terraformer/internal/cmd/approle.go
+++ b/terraformer/cmd/harp-terraformer/internal/cmd/approle.go
@@ -1,0 +1,83 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+
+	"github.com/elastic/harp-plugins/terraformer/pkg/terraformer"
+	"github.com/elastic/harp/pkg/sdk/cmdutil"
+	"github.com/elastic/harp/pkg/sdk/log"
+)
+
+var (
+	terraformerApproleInputSpec                string
+	terraformerApproleOutputPath               string
+	terraformerApproleDisableTokenWrap         bool
+	terraformerApproleDisableEnvironmentSuffix bool
+	terraformerApproleEnvironment              string
+)
+
+// -----------------------------------------------------------------------------
+
+var terraformerApproleCmd = func() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "approle",
+		Short: "policy and approle with approle engine",
+		Run:   runTerraformerApprole,
+	}
+
+	// Parameters
+	cmd.Flags().StringVar(&terraformerApproleInputSpec, "spec", "-", "AppRole specification path ('-' for stdin or filename)")
+	cmd.Flags().StringVar(&terraformerApproleOutputPath, "out", "-", "Output file ('-' for stdout or a filename)")
+	cmd.Flags().StringVar(&terraformerApproleEnvironment, "env", "production", "Target environment")
+	cmd.Flags().BoolVar(&terraformerApproleDisableTokenWrap, "no-token-wrap", false, "Disable token wrapping")
+	cmd.Flags().BoolVar(&terraformerApproleDisableEnvironmentSuffix, "no-env-suffix", false, "Disable environment suffix in role and policy names")
+
+	return cmd
+}
+
+func runTerraformerApprole(cmd *cobra.Command, _ []string) {
+	ctx, cancel := cmdutil.Context(cmd.Context(), "harp-terraformer-approle", conf.Debug.Enable, conf.Instrumentation.Logs.Level)
+	defer cancel()
+
+	var (
+		reader io.Reader
+		err    error
+	)
+
+	// Create input reader
+	reader, err = cmdutil.Reader(terraformerApproleInputSpec)
+	if err != nil {
+		log.For(ctx).Fatal("unable to open input specification", zap.Error(err), zap.String("path", terraformerApproleInputSpec))
+	}
+
+	// Create output writer
+	writer, err := cmdutil.Writer(terraformerApproleOutputPath)
+	if err != nil {
+		log.For(ctx).Fatal("unable to create output writer", zap.Error(err), zap.String("path", terraformerApproleOutputPath))
+	}
+
+	// Run terraformer
+	if err := terraformer.Run(ctx, reader, terraformerApproleEnvironment, terraformerApproleDisableTokenWrap, terraformerApproleDisableEnvironmentSuffix, terraformer.ApproleTemplate, writer); err != nil {
+		log.For(ctx).Fatal("unable to process specification", zap.Error(err), zap.String("path", terraformerApproleInputSpec))
+	}
+}

--- a/terraformer/cmd/harp-terraformer/internal/cmd/policy.go
+++ b/terraformer/cmd/harp-terraformer/internal/cmd/policy.go
@@ -29,9 +29,10 @@ import (
 )
 
 var (
-	terraformerPolicyInputSpec   string
-	terraformerPolicyOutputPath  string
-	terraformerPolicyEnvironment string
+	terraformerPolicyInputSpec                string
+	terraformerPolicyOutputPath               string
+	terraformerPolicyEnvironment              string
+	terraformerPolicyDisableEnvironmentSuffix bool
 )
 
 // -----------------------------------------------------------------------------
@@ -47,6 +48,7 @@ var terraformerPolicyCmd = func() *cobra.Command {
 	cmd.Flags().StringVar(&terraformerPolicyInputSpec, "spec", "-", "AppRole specification path ('-' for stdin or filename)")
 	cmd.Flags().StringVar(&terraformerPolicyOutputPath, "out", "-", "Output file ('-' for stdout or a filename)")
 	cmd.Flags().StringVar(&terraformerPolicyEnvironment, "env", "production", "Target environment")
+	cmd.Flags().BoolVar(&terraformerPolicyDisableEnvironmentSuffix, "no-env-suffix", false, "Disable environment suffix in policy names")
 
 	return cmd
 }
@@ -73,7 +75,7 @@ func runTerraformerPolicy(cmd *cobra.Command, _ []string) {
 	}
 
 	// Run terraformer
-	if err := terraformer.Run(ctx, reader, terraformerPolicyEnvironment, true, terraformer.PolicyTemplate, writer); err != nil {
+	if err := terraformer.Run(ctx, reader, terraformerPolicyEnvironment, true, terraformerPolicyDisableEnvironmentSuffix, terraformer.PolicyTemplate, writer); err != nil {
 		log.For(ctx).Fatal("unable to process specification", zap.Error(err), zap.String("path", terraformerPolicyInputSpec))
 	}
 }

--- a/terraformer/cmd/harp-terraformer/internal/cmd/root.go
+++ b/terraformer/cmd/harp-terraformer/internal/cmd/root.go
@@ -57,6 +57,7 @@ var mainCmd = func() *cobra.Command {
 
 	// Add subcommands
 	cmd.AddCommand(terraformerAgentCmd())
+	cmd.AddCommand(terraformerApproleCmd())
 	cmd.AddCommand(terraformerPolicyCmd())
 	cmd.AddCommand(terraformerServiceCmd())
 

--- a/terraformer/cmd/harp-terraformer/internal/cmd/service.go
+++ b/terraformer/cmd/harp-terraformer/internal/cmd/service.go
@@ -29,9 +29,10 @@ import (
 )
 
 var (
-	terraformerServiceInputSpec   string
-	terraformerServiceOutputPath  string
-	terraformerServiceEnvironment string
+	terraformerServiceInputSpec                string
+	terraformerServiceOutputPath               string
+	terraformerServiceEnvironment              string
+	terraformerServiceDisableEnvironmentSuffix bool
 )
 
 // -----------------------------------------------------------------------------
@@ -47,6 +48,7 @@ var terraformerServiceCmd = func() *cobra.Command {
 	cmd.Flags().StringVar(&terraformerServiceInputSpec, "spec", "-", "AppRole specification path ('-' for stdin or filename)")
 	cmd.Flags().StringVar(&terraformerServiceOutputPath, "out", "-", "Output file ('-' for stdout or a filename)")
 	cmd.Flags().StringVar(&terraformerServiceEnvironment, "env", "production", "Target environment")
+	cmd.Flags().BoolVar(&terraformerApproleDisableEnvironmentSuffix, "no-env-suffix", false, "Disable environment suffix in role and policy names")
 
 	return cmd
 }
@@ -73,7 +75,7 @@ func runTerraformerService(cmd *cobra.Command, _ []string) {
 	}
 
 	// Run terraformer
-	if err := terraformer.Run(ctx, reader, terraformerServiceEnvironment, true, terraformer.ServiceTemplate, writer); err != nil {
+	if err := terraformer.Run(ctx, reader, terraformerServiceEnvironment, true, terraformerServiceDisableEnvironmentSuffix, terraformer.ServiceTemplate, writer); err != nil {
 		log.For(ctx).Fatal("unable to process specification", zap.Error(err), zap.String("path", terraformerServiceInputSpec))
 	}
 }

--- a/terraformer/cmd/harp-terraformer/internal/cmd/service.go
+++ b/terraformer/cmd/harp-terraformer/internal/cmd/service.go
@@ -48,7 +48,7 @@ var terraformerServiceCmd = func() *cobra.Command {
 	cmd.Flags().StringVar(&terraformerServiceInputSpec, "spec", "-", "AppRole specification path ('-' for stdin or filename)")
 	cmd.Flags().StringVar(&terraformerServiceOutputPath, "out", "-", "Output file ('-' for stdout or a filename)")
 	cmd.Flags().StringVar(&terraformerServiceEnvironment, "env", "production", "Target environment")
-	cmd.Flags().BoolVar(&terraformerApproleDisableEnvironmentSuffix, "no-env-suffix", false, "Disable environment suffix in role and policy names")
+	cmd.Flags().BoolVar(&terraformerServiceDisableEnvironmentSuffix, "no-env-suffix", false, "Disable environment suffix in role and policy names")
 
 	return cmd
 }

--- a/terraformer/pkg/terraformer/compiler.go
+++ b/terraformer/pkg/terraformer/compiler.go
@@ -129,21 +129,28 @@ func pathCompiler(ring csov1.Ring, prefix []string, suffixFunc func() []*terrafo
 	return nil
 }
 
-func compile(env string, def *terraformerv1.AppRoleDefinition, specHash string, noTokenWrap bool) (*tmplModel, error) {
+func compile(env string, def *terraformerv1.AppRoleDefinition, specHash string, noTokenWrap bool, noEnvironmentSuffix bool) (*tmplModel, error) {
 	// Check arguments
 	if err := validate(def); err != nil {
 		return nil, err
 	}
 
+	// Check environment and suffix removal
+	objectName := slug.Make(fmt.Sprintf("%s %s", def.Meta.Name, env))
+	if noEnvironmentSuffix {
+		objectName = slug.Make(def.Meta.Name)
+	}
+
 	res := &tmplModel{
-		Date:             time.Now().UTC().Format(time.RFC3339),
-		SpecHash:         specHash,
-		Meta:             def.Meta,
-		Environment:      slug.Make(env),
-		RoleName:         slug.Make(def.Meta.Name),
-		ObjectName:       slug.Make(fmt.Sprintf("%s %s", def.Meta.Name, env)),
-		Namespaces:       map[string][]tmpSecretModel{},
-		DisableTokenWrap: noTokenWrap,
+		Date:                     time.Now().UTC().Format(time.RFC3339),
+		SpecHash:                 specHash,
+		Meta:                     def.Meta,
+		Environment:              slug.Make(env),
+		RoleName:                 slug.Make(def.Meta.Name),
+		ObjectName:               objectName,
+		Namespaces:               map[string][]tmpSecretModel{},
+		DisableTokenWrap:         noTokenWrap,
+		DisableEnvironmentSuffix: noEnvironmentSuffix,
 	}
 
 	if def.Spec.Namespaces != nil {

--- a/terraformer/pkg/terraformer/compiler.go
+++ b/terraformer/pkg/terraformer/compiler.go
@@ -129,7 +129,7 @@ func pathCompiler(ring csov1.Ring, prefix []string, suffixFunc func() []*terrafo
 	return nil
 }
 
-func compile(env string, def *terraformerv1.AppRoleDefinition, specHash string, noTokenWrap bool, noEnvironmentSuffix bool) (*tmplModel, error) {
+func compile(env string, def *terraformerv1.AppRoleDefinition, specHash string, noTokenWrap, noEnvironmentSuffix bool) (*tmplModel, error) {
 	// Check arguments
 	if err := validate(def); err != nil {
 		return nil, err

--- a/terraformer/pkg/terraformer/compiler_test.go
+++ b/terraformer/pkg/terraformer/compiler_test.go
@@ -27,10 +27,11 @@ import (
 
 func Test_compile(t *testing.T) {
 	type args struct {
-		env         string
-		def         *terraformerv1.AppRoleDefinition
-		specHash    string
-		noTokenWrap bool
+		env                 string
+		def                 *terraformerv1.AppRoleDefinition
+		specHash            string
+		noTokenWrap         bool
+		noEnvironmentSuffix bool
 	}
 	tests := []struct {
 		name    string
@@ -50,8 +51,9 @@ func Test_compile(t *testing.T) {
 					ApiVersion: "harp.elastic.co/terraformer/v1",
 					Kind:       "AppRoleDefinition",
 				},
-				noTokenWrap: false,
-				specHash:    "123456",
+				noTokenWrap:         false,
+				noEnvironmentSuffix: false,
+				specHash:            "123456",
 			},
 
 			wantErr: true,
@@ -65,6 +67,7 @@ func Test_compile(t *testing.T) {
 					Kind:       "AppRoleDefinition",
 					Meta:       &terraformerv1.AppRoleDefinitionMeta{},
 				},
+				noEnvironmentSuffix: false,
 			},
 			wantErr: true,
 		},
@@ -79,6 +82,7 @@ func Test_compile(t *testing.T) {
 						Name: "foo",
 					},
 				},
+				noEnvironmentSuffix: false,
 			},
 			wantErr: true,
 		},
@@ -94,6 +98,7 @@ func Test_compile(t *testing.T) {
 						Owner: "security@elastic.co",
 					},
 				},
+				noEnvironmentSuffix: false,
 			},
 			wantErr: true,
 		},
@@ -110,8 +115,9 @@ func Test_compile(t *testing.T) {
 						Description: "test",
 					},
 				},
-				noTokenWrap: false,
-				specHash:    "123456",
+				noTokenWrap:         false,
+				noEnvironmentSuffix: false,
+				specHash:            "123456",
 			},
 			wantErr: true,
 		},
@@ -129,8 +135,9 @@ func Test_compile(t *testing.T) {
 					},
 					Spec: &terraformerv1.AppRoleDefinitionSpec{},
 				},
-				noTokenWrap: false,
-				specHash:    "123456",
+				noTokenWrap:         false,
+				noEnvironmentSuffix: false,
+				specHash:            "123456",
 			},
 			wantErr: true,
 		},
@@ -150,15 +157,16 @@ func Test_compile(t *testing.T) {
 						Selector: &terraformerv1.AppRoleDefinitionSelector{},
 					},
 				},
-				noTokenWrap: false,
-				specHash:    "123456",
+				noTokenWrap:         false,
+				noEnvironmentSuffix: false,
+				specHash:            "123456",
 			},
 			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := compile(tt.args.env, tt.args.def, tt.args.specHash, tt.args.noTokenWrap)
+			_, err := compile(tt.args.env, tt.args.def, tt.args.specHash, tt.args.noTokenWrap, tt.args.noEnvironmentSuffix)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("compile() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -188,6 +196,7 @@ func Test_compile_Fuzz(t *testing.T) {
 		}
 		var specHash string
 		var tokenWrap bool
+		var noEnvSuffix bool
 
 		// Fuzz input
 		f.Fuzz(&env)
@@ -196,9 +205,10 @@ func Test_compile_Fuzz(t *testing.T) {
 		f.Fuzz(&spec.Spec.Custom)
 		f.Fuzz(&specHash)
 		f.Fuzz(&tokenWrap)
+		f.Fuzz(&noEnvSuffix)
 
 		// Execute
-		compile(env, spec, specHash, tokenWrap)
+		compile(env, spec, specHash, tokenWrap, noEnvSuffix)
 	}
 }
 

--- a/terraformer/pkg/terraformer/spec.go
+++ b/terraformer/pkg/terraformer/spec.go
@@ -37,7 +37,7 @@ import (
 // -----------------------------------------------------------------------------
 
 // Run the template generation
-func Run(_ context.Context, reader io.Reader, environmentParam string, noTokenWrap bool, noEnvironmentSuffix bool, templateRaw string, w io.Writer) error {
+func Run(_ context.Context, reader io.Reader, environmentParam string, noTokenWrap, noEnvironmentSuffix bool, templateRaw string, w io.Writer) error {
 	// Drain input reader
 	specificationRaw, err := io.ReadAll(reader)
 	if err != nil {

--- a/terraformer/pkg/terraformer/spec.go
+++ b/terraformer/pkg/terraformer/spec.go
@@ -37,7 +37,7 @@ import (
 // -----------------------------------------------------------------------------
 
 // Run the template generation
-func Run(_ context.Context, reader io.Reader, environmentParam string, noTokenWrap bool, templateRaw string, w io.Writer) error {
+func Run(_ context.Context, reader io.Reader, environmentParam string, noTokenWrap bool, noEnvironmentSuffix bool, templateRaw string, w io.Writer) error {
 	// Drain input reader
 	specificationRaw, err := io.ReadAll(reader)
 	if err != nil {
@@ -65,7 +65,7 @@ func Run(_ context.Context, reader io.Reader, environmentParam string, noTokenWr
 	specHash := sha256.Sum256(specProto)
 
 	// Compile the definition
-	m, err := compile(environmentParam, def, base64.StdEncoding.EncodeToString(specHash[:]), noTokenWrap)
+	m, err := compile(environmentParam, def, base64.StdEncoding.EncodeToString(specHash[:]), noTokenWrap, noEnvironmentSuffix)
 	if err != nil {
 		return fmt.Errorf("unable to compile specification: %w", err)
 	}


### PR DESCRIPTION
- [x] Add `appRole` subCommand to support the generation for appRoles in the default appRole engine.
- [x] Add option to generate an objectName without the environment suffix.
- [x] update test case for `noEnvironmentSuffix`