### PR TITLE
[Terraformer] Pin dependency versions to be compatible with Go 1.23

### DIFF
--- a/terraformer/magefile.go
+++ b/terraformer/magefile.go
@@ -51,7 +51,7 @@ func Tools() error {
 	color.Cyan("## Installing development tools")
 
 	color.Yellow("> Installing gotestsum")
-	if err := sh.RunV("go", "install", "gotest.tools/gotestsum@latest"); err != nil {
+	if err := sh.RunV("go", "install", "gotest.tools/gotestsum@v1.12.0"); err != nil {
 		return err
 	}
 
@@ -66,7 +66,7 @@ func Tools() error {
 	}
 
 	color.Yellow("> Installing cyclonedx-gomod")
-	if err := sh.RunV("go", "install", "github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest"); err != nil {
+	if err := sh.RunV("go", "install", "github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.9.0"); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
I was having trouble installing terraformer. First mage wouldn't let me use a newer version of Golang
```
Your golang compiler (go1.25.0) must be updated to [~1.23] to successfully compile all tools.
```
then when I installed 1.23, a couple of dependencies that we install with `latest` were incompatible with 1.23. This PR maintains the 1.23 compatibility by pinning dependency versions.

Somebody more familiar should probably upgrade to support more recent go versions.